### PR TITLE
[Feature/#18] Implement test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,11 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-core:5.7.0'
+    implementation 'net.bytebuddy:byte-buddy:1.14.18'
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintReqDto.java
+++ b/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintReqDto.java
@@ -2,10 +2,12 @@ package api.goraebab.domain.blueprint.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
 public class BlueprintReqDto {
 

--- a/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintResDto.java
+++ b/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintResDto.java
@@ -1,9 +1,12 @@
 package api.goraebab.domain.blueprint.dto;
 
 import api.goraebab.domain.remote.database.dto.StorageResDto;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -11,5 +14,10 @@ import lombok.Setter;
 public class BlueprintResDto extends BlueprintsResDto {
 
     private StorageResDto storageInfo;
+
+    public BlueprintResDto(Long blueprintId, String name, String data, Boolean isRemote, LocalDateTime dateCreated, LocalDateTime dateUpdated, StorageResDto storageInfo) {
+        super(blueprintId, name, data, isRemote, dateCreated, dateUpdated);
+        this.storageInfo = storageInfo;
+    }
 
 }

--- a/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintsResDto.java
+++ b/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintsResDto.java
@@ -1,5 +1,6 @@
 package api.goraebab.domain.blueprint.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@AllArgsConstructor
 @NoArgsConstructor
 public class BlueprintsResDto {
 

--- a/src/main/java/api/goraebab/domain/blueprint/entity/Blueprint.java
+++ b/src/main/java/api/goraebab/domain/blueprint/entity/Blueprint.java
@@ -3,15 +3,13 @@ package api.goraebab.domain.blueprint.entity;
 import api.goraebab.domain.remote.database.entity.Storage;
 import api.goraebab.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Entity
 @Table(name = "blueprint")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@NoArgsConstructor
 public class Blueprint extends BaseEntity {
 
   @Id

--- a/src/test/java/api/goraebab/controller/BlueprintControllerTest.java
+++ b/src/test/java/api/goraebab/controller/BlueprintControllerTest.java
@@ -1,0 +1,115 @@
+package api.goraebab.controller;
+
+import api.goraebab.domain.blueprint.controller.BlueprintController;
+import api.goraebab.domain.blueprint.dto.BlueprintReqDto;
+import api.goraebab.domain.blueprint.dto.BlueprintResDto;
+import api.goraebab.domain.blueprint.dto.BlueprintsResDto;
+import api.goraebab.domain.blueprint.service.BlueprintServiceImpl;
+import api.goraebab.domain.remote.database.dto.StorageResDto;
+import api.goraebab.domain.remote.database.entity.DBMS;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BlueprintController.class)
+public class BlueprintControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BlueprintServiceImpl blueprintService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Long storageId;
+    private Long blueprintId;
+    private BlueprintResDto blueprintResDto;
+    private BlueprintsResDto blueprintsResDto;
+    private BlueprintReqDto blueprintReqDto;
+
+    @BeforeEach
+    void setUp() {
+        storageId = 1L;
+        blueprintId = 1L;
+        StorageResDto storageResDto = StorageResDto.builder()
+                .storageId(storageId)
+                .host("123.123.123.123")
+                .port(8080)
+                .dbms(DBMS.MYSQL)
+                .name("Storage1")
+                .username("root")
+                .build();
+        blueprintResDto = new BlueprintResDto(blueprintId, "Blueprint1", "Data1", false, LocalDateTime.now(), LocalDateTime.now(), storageResDto);
+        blueprintsResDto = new BlueprintsResDto(blueprintId, "Blueprint1", "Data1", false, LocalDateTime.now(), LocalDateTime.now());
+        blueprintReqDto = new BlueprintReqDto("Blueprint2", "Data2");
+    }
+
+    @Test
+    @DisplayName("설계도 전체 목록 조회")
+    void getBlueprints() throws Exception {
+        List<BlueprintsResDto> blueprints = List.of(blueprintsResDto);
+        given(blueprintService.getBlueprints(storageId)).willReturn(blueprints);
+
+        mockMvc.perform(get("/storage/{storageId}/blueprints", storageId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("Blueprint1"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("설계도 단건 조회")
+    void getBlueprint() throws Exception {
+        given(blueprintService.getBlueprint(anyLong(), anyLong())).willReturn(blueprintResDto);
+
+        mockMvc.perform(get("/storage/{storageId}/blueprint/{blueprintId}", storageId, blueprintId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Blueprint1"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("설계도 저장")
+    void saveBlueprint() throws Exception {
+        mockMvc.perform(post("/storage/{storageId}/blueprint", storageId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(blueprintReqDto)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("설계도 수정")
+    void modifyBlueprint() throws Exception {
+        mockMvc.perform(patch("/storage/{storageId}/blueprint/{blueprintId}", storageId, blueprintId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(blueprintReqDto)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("설계도 삭제")
+    void deleteBlueprint() throws Exception {
+        mockMvc.perform(delete("/storage/{storageId}/blueprint/{blueprintId}", storageId, blueprintId))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+}

--- a/src/test/java/api/goraebab/controller/StorageControllerTest.java
+++ b/src/test/java/api/goraebab/controller/StorageControllerTest.java
@@ -1,0 +1,73 @@
+package api.goraebab.controller;
+
+import api.goraebab.domain.remote.database.controller.StorageController;
+import api.goraebab.domain.remote.database.dto.StorageReqDto;
+import api.goraebab.domain.remote.database.dto.StorageResDto;
+import api.goraebab.domain.remote.database.entity.DBMS;
+import api.goraebab.domain.remote.database.service.StorageServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(StorageController.class)
+public class StorageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StorageServiceImpl storageService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private StorageResDto storageResDto;
+    private StorageReqDto storageReqDto;
+
+    @BeforeEach
+    void setUp() {
+        storageResDto = new StorageResDto(1L, "123.123.123.123", 8080, DBMS.MYSQL, "Storage1", "root");
+        storageReqDto = new StorageReqDto("123.123.123.123", 8080, DBMS.MYSQL, "Storage1", "root", "password");
+    }
+
+    @Test
+    @DisplayName("원격 storage 목록 조회")
+    void loadStorages()throws Exception {
+        given(storageService.getStorages()).willReturn(List.of(storageResDto));
+
+        mockMvc.perform(get("/remote/storages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("Storage1"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("원격 storage 복사")
+    void copyStorage() throws Exception {
+        mockMvc.perform(post("/remote/storage/{storageId}/copy", 1L))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("원격 storage 삭제")
+    void disconnectStorage() throws Exception {
+        mockMvc.perform(delete("/remote/storage/{storageId}", 1L))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+}

--- a/src/test/java/api/goraebab/service/BlueprintServiceTest.java
+++ b/src/test/java/api/goraebab/service/BlueprintServiceTest.java
@@ -1,0 +1,127 @@
+package api.goraebab.service;
+
+import api.goraebab.domain.blueprint.dto.BlueprintReqDto;
+import api.goraebab.domain.blueprint.dto.BlueprintResDto;
+import api.goraebab.domain.blueprint.dto.BlueprintsResDto;
+import api.goraebab.domain.blueprint.entity.Blueprint;
+import api.goraebab.domain.blueprint.mapper.BlueprintMapper;
+import api.goraebab.domain.blueprint.repository.BlueprintRepository;
+import api.goraebab.domain.blueprint.service.BlueprintServiceImpl;
+import api.goraebab.domain.remote.database.dto.StorageResDto;
+import api.goraebab.domain.remote.database.entity.DBMS;
+import api.goraebab.domain.remote.database.entity.Storage;
+import api.goraebab.domain.remote.database.repository.StorageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class BlueprintServiceTest {
+
+    @Mock
+    private BlueprintRepository blueprintRepository;
+
+    @Mock
+    private StorageRepository storageRepository;
+
+    @InjectMocks
+    private BlueprintServiceImpl blueprintService;
+
+    private Long storageId;
+    private Long blueprintId;
+    private Storage storage;
+    private Blueprint blueprint;
+    private BlueprintReqDto blueprintReqDto;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        storageId = 1L;
+        blueprintId = 1L;
+        storage = new Storage(storageId, "123.123.123.123", 8080, DBMS.MYSQL, "Storage1", "root", "password");
+        blueprint = new Blueprint(blueprintId, "Blueprint1", "Data1", false, storage);
+        blueprintReqDto = new BlueprintReqDto("Blueprint2", "Data2");
+    }
+
+    @Test
+    @DisplayName("설계도 전체 목록 조회")
+    void getBlueprints() {
+        List<Blueprint> blueprints = List.of(blueprint);
+        given(blueprintRepository.findByStorageId(storageId)).willReturn(blueprints);
+        given(BlueprintMapper.INSTANCE.toBlueprintsResDtoList(blueprints)).willReturn(List.of(
+                new BlueprintsResDto(blueprintId, "Blueprint1", "Data1", false, LocalDateTime.now(), LocalDateTime.now())
+        ));
+
+        List<BlueprintsResDto> result = blueprintService.getBlueprints(storageId);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Blueprint1", result.get(0).getName());
+    }
+
+    @Test
+    @DisplayName("설계도 단건 조회")
+    void getBlueprint() {
+        Blueprint blueprint = new Blueprint(blueprintId, "Blueprint1", "Data1", false, storage);
+        StorageResDto storageResDto = StorageResDto.builder()
+                .storageId(storage.getId())
+                .host(storage.getHost())
+                .port(storage.getPort())
+                .dbms(storage.getDbms())
+                .name(storage.getName())
+                .username(storage.getUsername())
+                .build();
+
+        given(blueprintRepository.findByStorageIdAndId(storageId, blueprintId)).willReturn(Optional.of(blueprint));
+        given(BlueprintMapper.INSTANCE.toBlueprintResDto(blueprint)).willReturn(new BlueprintResDto(
+                blueprintId, "Blueprint1", "Data1", false, LocalDateTime.now(), LocalDateTime.now(), storageResDto
+        ));
+
+        BlueprintResDto result = blueprintService.getBlueprint(storageId, blueprintId);
+
+        assertNotNull(result);
+        assertEquals(blueprintId, result.getBlueprintId());
+        assertEquals("Blueprint1", result.getName());
+        assertEquals(storageId, result.getStorageInfo().getStorageId());
+        assertEquals(storage.getHost(), result.getStorageInfo().getHost());
+    }
+
+    @Test
+    @DisplayName("설계도 저장")
+    void saveBlueprint() {
+        given(storageRepository.findById(storageId)).willReturn(Optional.of(storage));
+
+        blueprintService.saveBlueprint(storageId, blueprintReqDto);
+
+        verify(blueprintRepository.save(argThat(bp ->
+                "Blueprint2".equals(bp.getName())
+                        && "Data2".equals(bp.getData())
+                        && storage.equals(bp.getStorage())
+                        && !bp.getIsRemote()
+        )));
+    }
+
+    @Test
+    @DisplayName("설계도 삭제")
+    void deleteBlueprint() {
+        given(blueprintRepository.findByStorageIdAndId(storageId, blueprintId));
+
+        blueprintService.deleteBlueprint(storageId, blueprintId);
+
+        verify(blueprintRepository).delete(blueprint);
+    }
+
+}

--- a/src/test/java/api/goraebab/service/StorageServiceTest.java
+++ b/src/test/java/api/goraebab/service/StorageServiceTest.java
@@ -1,0 +1,108 @@
+package api.goraebab.service;
+
+import api.goraebab.domain.blueprint.entity.Blueprint;
+import api.goraebab.domain.blueprint.mapper.BlueprintRowMapper;
+import api.goraebab.domain.blueprint.repository.BlueprintRepository;
+import api.goraebab.domain.remote.database.dto.StorageReqDto;
+import api.goraebab.domain.remote.database.dto.StorageResDto;
+import api.goraebab.domain.remote.database.entity.DBMS;
+import api.goraebab.domain.remote.database.entity.Storage;
+import api.goraebab.domain.remote.database.mapper.StorageMapper;
+import api.goraebab.domain.remote.database.repository.StorageRepository;
+import api.goraebab.domain.remote.database.service.StorageServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class StorageServiceTest {
+
+    @Mock
+    private StorageRepository storageRepository;
+
+    @Mock
+    private BlueprintRepository blueprintRepository;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private StorageServiceImpl storageService;
+
+    private Long storageId;
+    private Storage storage;
+    private StorageReqDto storageReqDto;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        storageId = 1L;
+        storageReqDto = new StorageReqDto("123.123.123.123", 8080, DBMS.MYSQL, "Storage1", "root", "password");
+        storage = new Storage(storageId, "123.123.123.123", 8080, DBMS.MYSQL, "Storage1", "root", "password");
+        ReflectionTestUtils.setField(storageService, "jdbcTemplate", jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("원격 storage 목록 조회")
+    void getStorages() {
+        List<Storage> storages = List.of(storage);
+        given(storageRepository.findAll()).willReturn(storages);
+        given(StorageMapper.INSTANCE.entityListToResDtoList(storages)).willReturn(List.of(
+                new StorageResDto(storageId, "123.123.123.123", 8080, DBMS.MYSQL, "Storage1", "root")
+        ));
+
+        List<StorageResDto> result = storageService.getStorages();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Storage1", result.get(0).getName());
+    }
+
+    @Test
+    @DisplayName("원격 storage 연결")
+    void connectStorage() {
+        given(storageRepository.save(any(Storage.class))).willReturn(storage);
+        given(this.jdbcTemplate.queryForList("SELECT * FROM goraebab.storage")).willReturn(List.of());
+
+        assertDoesNotThrow(() -> storageService.connectStorage(storageReqDto));
+
+        verify(jdbcTemplate, times(1)).queryForList("SELECT * FROM goraebab.storage");
+        verify(storageRepository, times(1)).save(any(Storage.class));
+    }
+
+    @Test
+    @DisplayName("원격 storage 복사")
+    void copyStorage() {
+        given(storageRepository.findById(storageId)).willReturn(Optional.of(storage));
+
+        List<Blueprint> blueprints = List.of(new Blueprint());
+        given(jdbcTemplate.query(anyString(), any(BlueprintRowMapper.class))).willReturn(blueprints);
+
+        storageService.copyStorage(storageId);
+
+        verify(blueprintRepository, times(1)).saveAll(blueprints);
+    }
+
+    @Test
+    @DisplayName("원격 storage 삭제")
+    void deleteStorage() {
+        storageService.deleteStorage(storageId);
+
+        verify(storageRepository, times(1)).deleteById(storageId);
+    }
+
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Todo

- [x] Implement test code for storage, blueprint controller and service components.

### Note
It seems that there is an error related to MockMaker. I would appreciate your help in resolving this issue. Below is the error message that has occurred. Once the error is resolved, I will complete the remote daemon-related code, proceed with testing, and handle any errors that arise.

`java.lang.IllegalStateException: Could not initialize plugin: interface org.mockito.plugins.MockMaker (alternate: null)
	at org.mockito.internal.configuration.plugins.PluginLoader$1.invoke(PluginLoader.java:84) ~[mockito-core-5.7.0.jar:na]
	at jdk.proxy3/jdk.proxy3.$Proxy79.isTypeMockable(Unknown Source) ~[na:na]
	at org.mockito.internal.util.MockUtil.typeMockabilityOf(MockUtil.java:78) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.util.MockCreationValidator.validateType(MockCreationValidator.java:22) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.creation.MockSettingsImpl.validatedSettings(MockSettingsImpl.java:274) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.creation.MockSettingsImpl.build(MockSettingsImpl.java:235) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.MockitoCore.mock(MockitoCore.java:86) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.Mockito.mock(Mockito.java:2101) ~[mockito-core-5.7.0.jar:na]
	at org.springframework.boot.test.mock.mockito.MockDefinition.createMock(MockDefinition.java:158) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.mock.mockito.MockitoPostProcessor.registerMock(MockitoPostProcessor.java:185) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.mock.mockito.MockitoPostProcessor.register(MockitoPostProcessor.java:167) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.mock.mockito.MockitoPostProcessor.postProcessBeanFactory(MockitoPostProcessor.java:141) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.mock.mockito.MockitoPostProcessor.postProcessBeanFactory(MockitoPostProcessor.java:129) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:363) ~[spring-context-6.1.11.jar:6.1.11]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:197) ~[spring-context-6.1.11.jar:6.1.11]
	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:789) ~[spring-context-6.1.11.jar:6.1.11]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:607) ~[spring-context-6.1.11.jar:6.1.11]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:754) ~[spring-boot-3.2.8.jar:3.2.8]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:456) ~[spring-boot-3.2.8.jar:3.2.8]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:335) ~[spring-boot-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.context.SpringBootContextLoader.lambda$loadContext$3(SpringBootContextLoader.java:137) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.util.function.ThrowingSupplier.get(ThrowingSupplier.java:58) ~[spring-core-6.1.11.jar:6.1.11]
	at org.springframework.util.function.ThrowingSupplier.get(ThrowingSupplier.java:46) ~[spring-core-6.1.11.jar:6.1.11]
	at org.springframework.boot.SpringApplication.withHook(SpringApplication.java:1463) ~[spring-boot-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.context.SpringBootContextLoader$ContextLoaderHook.run(SpringBootContextLoader.java:553) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.context.SpringBootContextLoader.loadContext(SpringBootContextLoader.java:137) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.context.SpringBootContextLoader.loadContext(SpringBootContextLoader.java:108) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:225) ~[spring-test-6.1.11.jar:6.1.11]
	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:152) ~[spring-test-6.1.11.jar:6.1.11]
	at org.springframework.test.context.support.DefaultTestContext.getApplicationContext(DefaultTestContext.java:130) ~[spring-test-6.1.11.jar:6.1.11]
	at org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener.postProcessFields(MockitoTestExecutionListener.java:122) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener.injectFields(MockitoTestExecutionListener.java:106) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener.prepareTestInstance(MockitoTestExecutionListener.java:63) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:260) ~[spring-test-6.1.11.jar:6.1.11]
	at org.springframework.test.context.junit.jupiter.SpringExtension.postProcessTestInstance(SpringExtension.java:163) ~[spring-test-6.1.11.jar:6.1.11]
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeTestInstancePostProcessors$10(ClassBasedTestDescriptor.java:378) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.executeAndMaskThrowable(ClassBasedTestDescriptor.java:383) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeTestInstancePostProcessors$11(ClassBasedTestDescriptor.java:378) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179) ~[na:na]
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[na:na]
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310) ~[na:na]
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735) ~[na:na]
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762) ~[na:na]
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeTestInstancePostProcessors(ClassBasedTestDescriptor.java:377) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$instantiateAndPostProcessTestInstance$6(ClassBasedTestDescriptor.java:290) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.instantiateAndPostProcessTestInstance(ClassBasedTestDescriptor.java:289) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$4(ClassBasedTestDescriptor.java:279) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at java.base/java.util.Optional.orElseGet(Optional.java:364) ~[na:na]
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$5(ClassBasedTestDescriptor.java:278) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.jupiter.engine.execution.TestInstancesProvider.getTestInstances(TestInstancesProvider.java:31) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$prepare$0(TestMethodTestDescriptor.java:106) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:105) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:69) ~[junit-jupiter-engine-5.10.3.jar:5.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$prepare$2(NodeTestTask.java:123) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.prepare(NodeTestTask.java:123) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:90) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511) ~[na:na]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511) ~[na:na]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54) ~[junit-platform-engine-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47) ~[junit-platform-launcher-1.10.3.jar:1.10.3]
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:119) ~[na:na]
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:94) ~[na:na]
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:89) ~[na:na]
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36) ~[na:na]
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24) ~[na:na]
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33) ~[na:na]
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94) ~[na:na]
	at jdk.proxy1/jdk.proxy1.$Proxy2.stop(Unknown Source) ~[na:na]
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193) ~[na:na]
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129) ~[na:na]
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100) ~[na:na]
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60) ~[na:na]
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56) ~[na:na]
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:119) ~[na:na]
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:66) ~[na:na]
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69) ~[gradle-worker.jar:na]
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74) ~[gradle-worker.jar:na]
Caused by: java.lang.IllegalStateException: Failed to load interface org.mockito.plugins.MockMaker implementation declared in java.lang.CompoundEnumeration@43d3aba5
	at org.mockito.internal.configuration.plugins.PluginInitializer.loadImpl(PluginInitializer.java:56) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.configuration.plugins.PluginLoader.loadPlugin(PluginLoader.java:65) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.configuration.plugins.PluginLoader.loadPlugin(PluginLoader.java:50) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.configuration.plugins.PluginRegistry.<init>(PluginRegistry.java:27) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.configuration.plugins.Plugins.<clinit>(Plugins.java:22) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.internal.MockitoCore.<clinit>(MockitoCore.java:73) ~[mockito-core-5.7.0.jar:na]
	at org.mockito.Mockito.<clinit>(Mockito.java:1683) ~[mockito-core-5.7.0.jar:na]
	at org.springframework.boot.test.mock.mockito.MockReset.withSettings(MockReset.java:81) ~[spring-boot-test-3.2.8.jar:3.2.8]
	at org.springframework.boot.test.mock.mockito.MockDefinition.createMock(MockDefinition.java:147) ~[spring-boot-test-3.2.8.jar:3.2.8]
	... 108 common frames omitted
Caused by: java.lang.reflect.InvocationTargetException: null
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:na]
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[na:na]
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[na:na]
	at org.mockito.internal.configuration.plugins.PluginInitializer.loadImpl(PluginInitializer.java:51) ~[mockito-core-5.7.0.jar:na]
	... 116 common frames omitted
Caused by: org.mockito.exceptions.base.MockitoInitializationException: 
Could not initialize inline Byte Buddy mock maker.
`
