### PR TITLE
[Bugfix/#27] Fix gradlew in LF format

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+gradlew text eol=lf


### PR DESCRIPTION
### Todo

- [x] Fix gradlew in LF format using `.gitattributes`


### Note

