### PR TITLE
[Docs/#31] Improve Swagger API documentation

### DIFF
--- a/src/main/java/api/goraebab/domain/blueprint/controller/BlueprintController.java
+++ b/src/main/java/api/goraebab/domain/blueprint/controller/BlueprintController.java
@@ -4,7 +4,11 @@ import api.goraebab.domain.blueprint.dto.BlueprintReqDto;
 import api.goraebab.domain.blueprint.dto.BlueprintResDto;
 import api.goraebab.domain.blueprint.dto.BlueprintsResDto;
 import api.goraebab.domain.blueprint.service.BlueprintServiceImpl;
+import api.goraebab.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,10 +27,23 @@ public class BlueprintController {
 
     private final BlueprintServiceImpl blueprintService;
 
-    @Operation(summary = "Retrieve the list of blueprints")
+    @Operation(summary = "Retrieve the list of blueprints",
+        description = "Fetches a list of blueprints associated with a specific storage ID.")
     @GetMapping("/blueprints")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Success"
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Failed to retrieve data from the database.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"RETRIEVAL_FAILED\", \"code\": 500, \"message\": \"Failed to retrieve data from the database.\", \"errors\": []}"))
+        )
     })
     public ResponseEntity<List<BlueprintsResDto>> getBlueprints(@PathVariable Long storageId) {
         List<BlueprintsResDto> blueprints = blueprintService.getBlueprints(storageId);
@@ -34,22 +51,76 @@ public class BlueprintController {
         return ResponseEntity.ok(blueprints);
     }
 
-    @Operation(summary = "Retrieve a single blueprint")
+    @Operation(summary = "Retrieve a single blueprint",
+        description = "Fetches the details of a single blueprint based on the provided blueprint ID.")
     @GetMapping("/blueprint/{blueprintId}")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Success"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "The type of the provided input value does not match the expected type.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "The requested resource could not be found.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"NOT_FOUND_VALUE\", \"code\": 404, \"message\": \"The requested resource could not be found.\", \"errors\": []}"))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Failed to retrieve data from the database.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"RETRIEVAL_FAILED\", \"code\": 500, \"message\": \"Failed to retrieve data from the database.\", \"errors\": []}"))
+        )
     })
-    public ResponseEntity<BlueprintResDto> getBlueprint(@PathVariable Long storageId,
-                                                        @PathVariable Long blueprintId) {
+    public ResponseEntity<BlueprintResDto> getBlueprint(
+        @PathVariable @Schema(description = "The unique identifier of the storage.") Long storageId,
+        @PathVariable @Schema(description = "The unique identifier of the blueprint.") Long blueprintId) {
         BlueprintResDto blueprint = blueprintService.getBlueprint(storageId, blueprintId);
 
         return ResponseEntity.ok(blueprint);
     }
 
-    @Operation(summary = "Save the blueprint to the local database")
+    @Operation(summary = "Save the blueprint to the local database",
+        description = "Saves a new blueprint associated with the specified storage ID to the local database.")
     @PostMapping("/blueprint")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Success"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "The type of the provided input value does not match the expected type.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Failed to save blueprint.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"SAVE_FAILED\", \"code\": 500, \"message\": \"Failed to save blueprint.\", \"errors\": []}"))
+        )
     })
     public ResponseEntity<Void> saveBlueprint(@PathVariable Long storageId,
                                               @RequestBody @Valid BlueprintReqDto blueprintReqDto) {
@@ -58,26 +129,72 @@ public class BlueprintController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "Modify the blueprint")
+    @Operation(summary = "Modify the blueprint",
+        description = "Updates the details of an existing blueprint in the local database.")
     @PatchMapping("/blueprint/{blueprintId}")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Success"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "The type of the provided input value does not match the expected type.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Failed to modify blueprint",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"MODIFY_FAILED\", \"code\": 500, \"message\": \"Failed to modify blueprint.\", \"errors\": []}"))
+        )
     })
-    public ResponseEntity<Void> modifyBlueprint(@PathVariable Long storageId,
-                                                @PathVariable Long blueprintId,
-                                                @RequestBody @Valid BlueprintReqDto blueprintReqDto) {
+    public ResponseEntity<Void> modifyBlueprint(
+        @PathVariable @Schema(description = "The unique identifier of the storage.") Long storageId,
+        @PathVariable @Schema(description = "The unique identifier of the blueprint.") Long blueprintId,
+        @RequestBody @Valid BlueprintReqDto blueprintReqDto) {
         blueprintService.modifyBlueprint(storageId, blueprintId, blueprintReqDto);
 
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "Delete the blueprint")
+    @Operation(summary = "Delete the blueprint",
+        description = "Deletes the specified blueprint from the local database based on the blueprint ID.")
     @DeleteMapping("/blueprint/{blueprintId}")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Success"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "The type of the provided input value does not match the expected type.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "Failed to delete the specified resource.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        "{\"status\": \"DELETE_FAILED\", \"code\": 500, \"message\": \"Failed to delete the specified resource.\", \"errors\": []}"))
+        )
     })
-    public ResponseEntity<Void> deleteBlueprint(@PathVariable Long storageId,
-                                                @PathVariable Long blueprintId) {
+    public ResponseEntity<Void> deleteBlueprint(
+        @PathVariable @Schema(description = "The unique identifier of the storage.") Long storageId,
+        @PathVariable @Schema(description = "The unique identifier of the blueprint.") Long blueprintId) {
         blueprintService.deleteBlueprint(storageId, blueprintId);
 
         return ResponseEntity.ok().build();

--- a/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintReqDto.java
+++ b/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintReqDto.java
@@ -1,5 +1,6 @@
 package api.goraebab.domain.blueprint.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -13,9 +14,11 @@ public class BlueprintReqDto {
 
     @NotBlank(message = "Name must not be blank")
     @Size(max = 255, message = "Name must be less than 255 characters")
+    @Schema(description = "The name of the blueprint.", example = "Project1 blueprint")
     private String name;
 
     @NotBlank(message = "Data must not be blank")
+    @Schema(description = "The raw data associated with the blueprint.")
     private String data;
 
 }

--- a/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintsResDto.java
+++ b/src/main/java/api/goraebab/domain/blueprint/dto/BlueprintsResDto.java
@@ -1,5 +1,6 @@
 package api.goraebab.domain.blueprint.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,16 +14,22 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class BlueprintsResDto {
 
+    @Schema(description = "The unique identifier of the blueprint.", example = "1")
     private Long blueprintId;
 
+    @Schema(description = "The name of the blueprint.", example = "Project1 blueprint")
     private String name;
 
+    @Schema(description = "The raw data associated with the blueprint.")
     private String data;
 
+    @Schema(description = "The flag indicating whether the blueprint is stored remotely.", example = "true")
     private Boolean isRemote;
 
+    @Schema(description = "The date and time when the blueprint was created.", example = "2023-09-28T12:34:56")
     private LocalDateTime dateCreated;
 
+    @Schema(description = "The date and time when the blueprint was last updated.", example = "2023-09-28T12:34:56")
     private LocalDateTime dateUpdated;
 
 }

--- a/src/main/java/api/goraebab/domain/remote/database/controller/StorageController.java
+++ b/src/main/java/api/goraebab/domain/remote/database/controller/StorageController.java
@@ -3,8 +3,10 @@ package api.goraebab.domain.remote.database.controller;
 import api.goraebab.domain.remote.database.dto.StorageReqDto;
 import api.goraebab.domain.remote.database.dto.StorageResDto;
 import api.goraebab.domain.remote.database.service.StorageServiceImpl;
+import api.goraebab.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -27,11 +29,24 @@ public class StorageController {
 
   private final StorageServiceImpl storageServiceImpl;
 
-  @Operation(summary = "Load remote daemons info from database")
+  @Operation(summary = "Load remote daemons info from database.",
+      description = "This API fetches the info of remote storage daemons from the database "
+          + "and returns a list of StorageResDto.")
   @GetMapping("/remote/storages")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", content = {
-          @Content(schema = @Schema(implementation = StorageResDto.class))}),
+      @ApiResponse(
+          responseCode = "200",
+          description = "Success",
+          content = @Content(schema = @Schema(implementation = StorageResDto.class))),
+      @ApiResponse(
+          responseCode = "500",
+          description = "Failed to retrieve data from the database.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"RETRIEVAL_FAILED\", \"code\": 500, \"message\": \"Failed to retrieve data from the database.\", \"errors\": []}"))
+      )
   })
   public ResponseEntity<List<StorageResDto>> loadStorages() {
     List<StorageResDto> storageResDtoListList = storageServiceImpl.getStorages();
@@ -39,10 +54,32 @@ public class StorageController {
     return ResponseEntity.ok(storageResDtoListList);
   }
 
-    @Operation(summary = "Connect and save remote storage in database")
+  @Operation(summary = "Connect and save remote storage in database.",
+      description = "Establishes a connection to a remote storage and saves the connection details "
+          + "in the local database.")
   @PostMapping("/remote/storage/connect")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200")
+      @ApiResponse(
+          responseCode = "200",
+          description = "Success"),
+      @ApiResponse(
+          responseCode = "400",
+          description = "The type of the provided input value does not match the expected type.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "Failed to establish a connection to the external service or database.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"CONNECTION_FAILED\", \"code\": 500, \"message\": \"Failed to establish a connection to the external service or database.\", \"errors\": []}"))
+      )
   })
   public ResponseEntity<Void> connectStorage(
       @RequestBody @Valid StorageReqDto storageReqDto) {
@@ -51,25 +88,69 @@ public class StorageController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "Copy remote storage blueprints into database")
+  @Operation(summary = "Copy remote storage blueprints into database",
+      description = "Copies the blueprints of a remote storage into the local database "
+          + "based on the provided storage ID.")
   @PostMapping("/remote/storage/{storageId}/copy")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200")
+      @ApiResponse(
+          responseCode = "200",
+          description = "Success"),
+      @ApiResponse(
+          responseCode = "400",
+          description = "The type of the provided input value does not match the expected type.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "Failed to copy data from remote storage to local storage.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"COPY_FAILED\", \"code\": 500, \"message\": \"Failed to copy data from remote storage to local storage.\", \"errors\": []}"))
+      )
   })
   public ResponseEntity<Void> copyStorage(
-      @PathVariable Long storageId) {
+      @PathVariable @Schema(description = "The unique identifier of the storage to be copied.") Long storageId) {
     storageServiceImpl.copyStorage(storageId);
 
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "Delete remote storage in database")
+  @Operation(summary = "Delete remote storage in database",
+      description = "Deletes the connection and stored info of a remote storage "
+          + "from the database based on the provided storage ID.")
   @DeleteMapping("/remote/storage/{storageId}")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200")
+      @ApiResponse(
+          responseCode = "200",
+          description = "Success"),
+      @ApiResponse(
+          responseCode = "400",
+          description = "The type of the provided input value does not match the expected type.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "Failed to delete the specified resource.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"DELETE_FAILED\", \"code\": 500, \"message\": \"Failed to delete the specified resource.\", \"errors\": []}"))
+      )
   })
   public ResponseEntity<Void> disconnectStorage(
-      @PathVariable Long storageId) {
+      @PathVariable @Schema(description = "The unique identifier of the storage to be deleted.") Long storageId) {
     storageServiceImpl.deleteStorage(storageId);
 
     return ResponseEntity.ok().build();

--- a/src/main/java/api/goraebab/domain/remote/database/dto/StorageReqDto.java
+++ b/src/main/java/api/goraebab/domain/remote/database/dto/StorageReqDto.java
@@ -2,6 +2,7 @@ package api.goraebab.domain.remote.database.dto;
 
 import api.goraebab.domain.remote.database.entity.DBMS;
 import api.goraebab.global.util.validator.ValidEnum;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -21,28 +22,35 @@ public class StorageReqDto {
 
   @NotBlank
   @Size(max = 255, message = "Host must be less than 255 characters")
+  @Schema(description = "The host address of the storage.", example = "255.255.255.255")
   private String host;
 
   @NotNull
   @Positive
   @Max(value = 65535, message = "Port must be 1 ~ 65535")
+  @Schema(description = "The port number used to connect to the storage.", example = "3306")
   private Integer port;
 
   @ValidEnum(target = DBMS.class)
+  @Schema(description = "The type of DBMS. Choose one from [MYSQL, POSTGRESQL, ORACLE, or SQLSERVER]."
+  ,example = "MYSQL")
   private DBMS dbms;
 
   @NotBlank
   @Size(max = 255, message = "Name must be less than 255 characters")
+  @Schema(description = "The name of the storage.", example = "Gorae's DB")
   private String name;
 
   @NotBlank
   @Pattern(regexp = USERNAME_REGEX,
       message = "Username must be 1-32 characters long and can only contain letters, numbers, and underscores")
+  @Schema(description = "The username used to connect to DBMS.", example = "root")
   private String username;
 
   @NotBlank
   @Pattern(regexp = PASSWORD_REGEX,
       message = "Password must be 8-128 characters long and include at least one uppercase letter, one lowercase letter, one number, and one special character.")
+  @Schema(description = "The password used to connect to DBMS.", example = "root")
   private String password;
 
 

--- a/src/main/java/api/goraebab/domain/remote/database/dto/StorageResDto.java
+++ b/src/main/java/api/goraebab/domain/remote/database/dto/StorageResDto.java
@@ -1,29 +1,39 @@
 package api.goraebab.domain.remote.database.dto;
 
 import api.goraebab.domain.remote.database.entity.DBMS;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "Represents the storage info.")
 public class StorageResDto {
 
+  @Schema(description = "The unique identifier of the storage.", example = "1")
   private Long storageId;
 
+  @Schema(description = "The host address of the storage.", example = "255.255.255.255")
   private String host;
 
+  @Schema(description = "The port number used to connect to the storage.", example = "3306")
   private Integer port;
 
+  @Schema(description = "The type of DBMS. Choose one from [MYSQL, POSTGRESQL, ORACLE, or SQLSERVER]."
+      , example = "MYSQL")
   private DBMS dbms;
 
+  @Schema(description = "The name of the storage.", example = "Gorae's DB")
   private String name;
 
+  @Schema(description = "The username used to connect to DBMS.", example = "root")
   private String username;
 
 
   @Builder
-  public StorageResDto(Long storageId, String host, Integer port, DBMS dbms, String name, String username) {
+  public StorageResDto(Long storageId, String host, Integer port, DBMS dbms, String name,
+      String username) {
     this.storageId = storageId;
     this.host = host;
     this.port = port;

--- a/src/main/java/api/goraebab/domain/remote/docker/controller/DaemonController.java
+++ b/src/main/java/api/goraebab/domain/remote/docker/controller/DaemonController.java
@@ -3,8 +3,10 @@ package api.goraebab.domain.remote.docker.controller;
 import api.goraebab.domain.remote.docker.dto.DaemonReqDto;
 import api.goraebab.domain.remote.docker.dto.DaemonResDto;
 import api.goraebab.domain.remote.docker.service.DaemonService;
+import api.goraebab.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -27,11 +29,24 @@ public class DaemonController {
 
   private final DaemonService daemonService;
 
-  @Operation(summary = "Load remote daemons info from database")
+  @Operation(summary = "Load remote daemons info from database",
+      description = "Retrieves a list of remote daemons stored in the database.")
   @GetMapping("/remote/daemons")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", content = {
-      @Content(schema = @Schema(implementation = DaemonResDto.class))}),
+      @ApiResponse(
+          responseCode = "200",
+          description = "Success",
+          content = @Content(schema = @Schema(implementation = DaemonResDto.class))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "Failed to retrieve data from the database.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"RETRIEVAL_FAILED\", \"code\": 500, \"message\": \"Failed to retrieve data from the database.\", \"errors\": []}"))
+      )
   })
   public ResponseEntity<List<DaemonResDto>> loadDaemons() {
     List<DaemonResDto> daemonList = daemonService.getDaemons();
@@ -39,10 +54,32 @@ public class DaemonController {
     return ResponseEntity.ok(daemonList);
   }
 
-  @Operation(summary = "Connect and save remote daemon in database")
+  @Operation(summary = "Connect and save remote daemon in database",
+      description = "Establishes a connection to a remote daemon and saves its details in the database.")
   @PostMapping("/remote/daemon/connect")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200")
+      @ApiResponse(
+          responseCode = "200",
+          description = "Success"
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "The type of the provided input value does not match the expected type.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "Failed to establish a connection to the external service or database.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"CONNECTION_FAILED\", \"code\": 500, \"message\": \"Failed to establish a connection to the external service or database.\", \"errors\": []}"))
+      )
   })
   public ResponseEntity<Void> connectDaemon(@RequestBody @Valid DaemonReqDto daemonReqDto) {
     daemonService.connectDaemon(daemonReqDto);
@@ -50,12 +87,35 @@ public class DaemonController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "Delete remote daemon in database")
+  @Operation(summary = "Delete remote daemon in database",
+      description = "Deletes the connection and stored information of a remote daemon from the database based on the provided daemon ID.")
   @DeleteMapping("/remote/daemon/{daemonId}")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200")
+      @ApiResponse(
+          responseCode = "200",
+          description = "Success"
+      ),
+      @ApiResponse(
+          responseCode = "400",
+          description = "The type of the provided input value does not match the expected type.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"INVALID_TYPE_VALUE\", \"code\": 400, \"message\": \"The type of the provided input value does not match the expected type.\", \"errors\": []}"))
+      ),
+      @ApiResponse(
+          responseCode = "500",
+          description = "Failed to delete the specified resource.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+              examples =
+              @ExampleObject(
+                  value =
+                      "{\"status\": \"DELETE_FAILED\", \"code\": 500, \"message\": \"Failed to delete the specified resource.\", \"errors\": []}"))
+      )
   })
-  public ResponseEntity<Void> disconnectDaemon(@PathVariable Long daemonId) {
+  public ResponseEntity<Void> disconnectDaemon(
+      @PathVariable @Schema(description = "The unique identifier of the Docker daemon to be deleted.") Long daemonId) {
     daemonService.deleteDaemon(daemonId);
 
     return ResponseEntity.ok().build();

--- a/src/main/java/api/goraebab/domain/remote/docker/dto/DaemonReqDto.java
+++ b/src/main/java/api/goraebab/domain/remote/docker/dto/DaemonReqDto.java
@@ -1,5 +1,6 @@
 package api.goraebab.domain.remote.docker.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -15,15 +16,18 @@ public class DaemonReqDto {
 
   @NotBlank
   @Size(max = 255, message = "Host must be less than 255 characters")
+  @Schema(description = "The host address of the Docker daemon.", example = "255.255.255.255")
   private String host;
 
   @NotNull
   @Positive
   @Max(value = 65535, message = "Port must be 1 ~ 65535")
+  @Schema(description = "The port number used to connect to the Docker daemon.", example = "2375")
   private Integer port;
 
   @NotBlank
   @Size(max = 255, message = "Name must be less than 255 characters")
+  @Schema(description = "The name of the Docker daemon.", example = "Gorae's Docker daemon")
   private String name;
 
   @Builder

--- a/src/main/java/api/goraebab/domain/remote/docker/dto/DaemonResDto.java
+++ b/src/main/java/api/goraebab/domain/remote/docker/dto/DaemonResDto.java
@@ -1,5 +1,6 @@
 package api.goraebab.domain.remote.docker.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,12 +9,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DaemonResDto {
 
+  @Schema(description = "The unique identifier of the Docker daemon.", example = "1")
   private Long daemonId;
 
+  @Schema(description = "The host address of the Docker daemon.", example = "255.255.255.255")
   private String host;
 
+  @Schema(description = "The port number used to connect to the Docker daemon.", example = "2375")
   private Integer port;
 
+  @Schema(description = "The name of the Docker daemon.", example = "Gorae's Docker daemon")
   private String name;
 
 

--- a/src/main/java/api/goraebab/global/exception/ErrorCode.java
+++ b/src/main/java/api/goraebab/global/exception/ErrorCode.java
@@ -39,8 +39,8 @@ public enum ErrorCode {
      * blueprint error
      */
 
-    SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to save blueprint"),
-    MODIFY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to modify blueprint");
+    SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to save blueprint."),
+    MODIFY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to modify blueprint.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
We aim to enhance the current Swagger API documentation by adding more detailed descriptions, examples, and standardized error responses. This improvement will increase the clarity and usability of the API for developers, reducing the potential for misinterpretation and errors during implementation.

### To do

1. For each field in DTOs, add specific descriptions that explain their role, valid values, and any constraints.
2. Use a consistent ErrorResponse schema across all endpoints to provide structured error information, including error codes, messages.
3. Add examples for request bodies, parameters, and responses for all endpoints.


### Note
While writing docs and testing, I found that `ErrorResponse` are not all mapped. It causes unexpected Reponse format like this.
```json
{
  "timestamp": "2024-09-28T14:58:48.002+00:00",
  "status": 500,
  "error": "Internal Server Error",
  "path": "/remote/storage/connect"
}
```

Correct Response
```json
{
  "status": "INVALID_TYPE_VALUE",
  "code": 400,
  "message": "The type of the provided input value does not match the expected type.",
  "errors": []
}
```

Error handling need to be fixed.


### What needs to be improved
Precise Error handling

