### PR TITLE
[Bugfix/#43] Replace RestTemplate with RestClient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN chmod +x ./gradlew
 
 RUN ./gradlew clean build -x test
 
-ENTRYPOINT ["java", "-jar", "build/libs/Goraebab-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-Xdebug","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005", "-jar", "build/libs/Goraebab-0.0.1-SNAPSHOT.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'jakarta.activation:jakarta.activation-api:2.1.3'
 
+    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       context: ./
     ports:
       - "2387:2387"
+      - "5005:5005"
     environment:
       spring.profiles.active: mysql
       spring.datasource.url: jdbc:mysql://172.18.0.20:3306/goraebab

--- a/src/main/java/api/goraebab/domain/config/AppConfig.java
+++ b/src/main/java/api/goraebab/domain/config/AppConfig.java
@@ -1,0 +1,15 @@
+package api.goraebab.domain.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class AppConfig {
+
+  @Bean
+  public RestClient restClient() {
+    return RestClient.create();
+  }
+
+}

--- a/src/main/java/api/goraebab/global/util/ConnectionUtil.java
+++ b/src/main/java/api/goraebab/global/util/ConnectionUtil.java
@@ -8,24 +8,19 @@ import static api.goraebab.domain.remote.database.entity.DBMS.SQLSERVER;
 import api.goraebab.domain.remote.database.dto.StorageReqDto;
 import api.goraebab.domain.remote.database.entity.DBMS;
 import api.goraebab.domain.remote.database.entity.Storage;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.Objects;
 import javax.sql.DataSource;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 public class ConnectionUtil {
 
-  private static final RestTemplate restTemplate = new RestTemplate();
+  private static final RestClient restClient = RestClient.create();
 
   private static final String DOCKER_PING_URL = "http://%s:%d/_ping";
   private static final String DOCKER_OK_RESPONSE_BODY = "OK";
-  private static final String HARBOR_PING_URL = "http://%s:%d/api/v2.0/ping";
-  private static final String HARBOR_OK_RESPONSE_BODY = "Pong";
 
   private static final String DEFAULT_DATABASE_NAME = "goraebab";
   private static final Map<DBMS, String> DBMS_DRIVERS = Map.of(
@@ -71,51 +66,13 @@ public class ConnectionUtil {
   public static boolean testDockerPing(String host, int port) {
     String requestUrl = String.format(DOCKER_PING_URL, host, port);
     try {
-      String response = restTemplate.getForObject(requestUrl, String.class);
+      String response = restClient.get()
+          .uri(requestUrl)
+          .retrieve()
+          .body(String.class);
       return Objects.equals(response, DOCKER_OK_RESPONSE_BODY);
     } catch (RestClientException e) {
       return false;
-    }
-  }
-
-  public static boolean testHarborPing(String host, int port) {
-    String requestUrl = String.format(HARBOR_PING_URL, host, port);
-    try {
-      String response = restTemplate.getForObject(requestUrl, String.class);
-      return Objects.equals(response, HARBOR_OK_RESPONSE_BODY);
-    } catch (RestClientException e) {
-      return false;
-    }
-  }
-
-  public static void harborLogin(String host, int port, String username, String password) {
-    final String[] command = {
-        "docker", "login", host + ":" + port,
-        "--username=" + username,
-        "--password=" + password
-    };
-    try {
-      ProcessBuilder processBuilder = new ProcessBuilder(command);
-      processBuilder.redirectErrorStream(true);
-      Process process = processBuilder.start();
-
-      try (BufferedReader reader = new BufferedReader(
-          new InputStreamReader(process.getInputStream()))) {
-        String line;
-        while ((line = reader.readLine()) != null) {
-          System.out.println(line);
-        }
-      }
-
-      int exitCode = process.waitFor();
-      if (exitCode == 0) {
-        System.out.println("Harbor login successful!");
-      } else {
-        System.out.println("Harbor login failed.");
-        throw new RuntimeException("Harbor connection failed");
-      }
-    } catch (IOException | InterruptedException e) {
-      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
### Todo
- [x] Add container debug function (port:5005)
- [x] Replace `RestTemplate` with `RestClient`


### Note
During testing, I encountered an issue where the remote connection was not working. Initially, I used `RestTemplate` to verify the connection, but for some unknown reason, it resulted in a `Connection Refused` error. Despite trying multiple solutions, none were successful. However, after switching to `RestClient`, which is a more recent addition, the connection worked as expected.