### PR TITLE
[Bugfix/#42] Change Linux image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 
 WORKDIR /app
 
 COPY . .
+
+RUN apt-get update && apt-get install -y findutils
 
 RUN chmod +x ./gradlew
 


### PR DESCRIPTION
### Todo
- [x] Improve Dockerfile compatability


### Note
The current Dockerfile causes issues on macOS, though the exact technical reason is unclear. Previously, we used Alpine Linux, a very lightweight operating system, but have replaced it with a Debian-based slim image that includes more essential utilities.