### PR TITLE
[Bugfix/#62] Add network validation check

### DIFF
--- a/src/main/java/api/goraebab/domain/blueprint/service/DockerSyncServiceImpl.java
+++ b/src/main/java/api/goraebab/domain/blueprint/service/DockerSyncServiceImpl.java
@@ -44,6 +44,8 @@ public class DockerSyncServiceImpl implements DockerSyncService {
     private static final String MOUNT_BIND_TYPE = "bind";
     private static final String MOUNT_VOLUME_TYPE = "volume";
     private static final String CONTAINER_RUNNING_STATE = "running";
+    private static final String DEFAULT_BRIDGE_NETWORK_SUBNET = "172.17.0.0/16";
+    private static final String DEFAULT_BRIDGE_NETWORK_NAME = "bridge";
 
 
     @Override
@@ -93,8 +95,20 @@ public class DockerSyncServiceImpl implements DockerSyncService {
         }
     }
 
+    private void customNetworkValidationCheck(List<CustomNetwork> customNetworkList) {
+        for (CustomNetwork customNetwork : customNetworkList) {
+            for (CustomConfig config : customNetwork.getCustomIpam().getCustomConfig()) {
+                if (customNetwork.getName().equals(DEFAULT_BRIDGE_NETWORK_NAME)
+                    && config.getSubnet().equals(DEFAULT_BRIDGE_NETWORK_SUBNET)) {
+                    throw new CustomException(ErrorCode.NETWORK_CREATION_FAILED);
+                }
+            }
+        }
+    }
+
     private void syncNetworks(DockerClient dockerClient, List<CustomNetwork> customNetworkList) throws DockerException {
 
+        customNetworkValidationCheck(customNetworkList);
         List<Network> existingNetworks = dockerClient.listNetworksCmd().exec();
 
         for (CustomNetwork customNetwork : customNetworkList) {

--- a/src/main/java/api/goraebab/global/exception/ErrorCode.java
+++ b/src/main/java/api/goraebab/global/exception/ErrorCode.java
@@ -46,7 +46,8 @@ public enum ErrorCode {
     CONTAINER_SYNC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "An error occurred during the container synchronization process."),
     CONTAINER_REMOVAL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to stop or remove the specified container."),
     CONTAINER_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to create the specified Docker container."),
-    CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to convert the processed data to JSON format.");
+    CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to convert the processed data to JSON format."),
+    NETWORK_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Failed to create the specified Docker network.");
 
     private final HttpStatus status;
 


### PR DESCRIPTION
### Todo
- [x] Add network validation check


### Note
```json
{
  "blueprintName": "test",
  "processedData": {
    "host": [
      {
        "name": "my_new_host",
        "isLocal": true,
        "ip": "",
        "network": [
          {
            "name": "bridge",
            "driver": "bridge",
            "ipam": {
              "config": [
                {
                  "subnet": "172.19.0.0/16"
                }
              ]
            },
            "containers": [
              {
                "containerName": "postgre_test",
                "image": {
                  "imageId": "sha256:20a112cf9de2bf3cd08f6aa7e9fc8020798783330ceccdde3bc2f2e2b1ebc37e",
                  "name": "goraebab-frontend",
                  "tag": "latest"
                },
                "networkSettings": {
                  "gateway": "172.20.0.1",
                  "ipAddress": "172.20.0.20"
                },
                "ports": [
                  {
                    "privatePort": 8080,
                    "publicPort": 8080
                  }
                ],
                "mounts": [
                ],
                "env": [
                ],
                "cmd": [
                ]
              }
            ]
          }
        ],
        "volume": [
        ]
      }
    ]
  }
}
```

Added a validation check to handle cases where `"name": "bridge"` is specified in the request with a subnet other than Docker's default `172.17.0.0/16`. Previously, no error was thrown, and a 200 status was returned despite the incorrect subnet.