### PR TITLE
[bugfix/#69] Add frontend in EXCLUDED_CONTAINER_NAME

### DIFF
--- a/src/main/java/api/goraebab/domain/blueprint/service/DockerSyncServiceImpl.java
+++ b/src/main/java/api/goraebab/domain/blueprint/service/DockerSyncServiceImpl.java
@@ -44,7 +44,7 @@ public class DockerSyncServiceImpl implements DockerSyncService {
     private static final String LOCAL_HOST_IP = "host.docker.internal";
     private static final int DOCKER_DAEMON_PORT = 2375;
     public static final Set<String> EXCLUDED_CONTAINER_NAME = new HashSet<>(
-            Arrays.asList("/goraebab_spring", "/goraebab_mysql", "/goraebab_mariadb",
+            Arrays.asList("goraebab_next", "/goraebab_spring", "/goraebab_mysql", "/goraebab_mariadb",
                     "/goraebab_postgresql", "/goraebab_oracle"));
     private static final Set<String> EXCLUDED_NETWORK_SET = new HashSet<>(
             Arrays.asList("bridge", "host", "none", "goraebab_network"));


### PR DESCRIPTION
### Todo
- [x] Add frontend in EXCLUDED_CONTAINER_NAME


### Note
After running all servers as containers and executing docker sync from the frontend server, a bug was discovered where the frontend server was not caught by the filter and was mistakenly deleted.